### PR TITLE
General changes - CAN, light codes

### DIFF
--- a/s2c_sensor_module/src/config/conf_can.h
+++ b/s2c_sensor_module/src/config/conf_can.h
@@ -70,7 +70,7 @@
  * quanta which means the bit rate is 8MHz / 16 = 500KHz.
  */
 /* Nominal bit Baud Rate Prescaler */
-#define CONF_CAN_NBTP_NBRP_VALUE    5
+#define CONF_CAN_NBTP_NBRP_VALUE    1//This value has been changes from 5 to 1
 /* Nominal bit (Re)Synchronization Jump Width */
 #define CONF_CAN_NBTP_NSJW_VALUE    3
 /* Nominal bit Time segment before sample point */
@@ -85,7 +85,7 @@
  * quanta which means the bit rate is 8MHz / 16 = 500KHz.
  */
 /* Data bit Baud Rate Prescaler */
-#define CONF_CAN_DBTP_DBRP_VALUE    5
+#define CONF_CAN_DBTP_DBRP_VALUE    1//This value has been changes from 5 to 1
 /* Data bit (Re)Synchronization Jump Width */
 #define CONF_CAN_DBTP_DSJW_VALUE    3
 /* Data bit Time segment before sample point */


### PR DESCRIPTION
Change the configuration of the CAN packet to compensate for the 1/3 clock shift error discussed in issue #1. Also Added in 'flash codes' for board pin number and can status.

Flash codes:
Pin number: If the correct boolean is set to true (currently true) then on load up after board is configured it will blink rapidly(to get your attention) then do a binary flash of the number of the board ID.  The least significant bit to most. This is not done asynchronously and will delay the board's recording by a couple of seconds. After this flash out the light will turn on to signify that the board is recording. 

CAN status: If there is a CAN error it will rapidly blink the led. It is enabled by a separate boolean and is currently disabled.